### PR TITLE
Github action for building apk on new git tags

### DIFF
--- a/.github/workflows/flutter-build.yaml
+++ b/.github/workflows/flutter-build.yaml
@@ -26,6 +26,6 @@ jobs:
       - run: flutter analyze
       - run: flutter test
       - run: flutter build apk --release
-      - uses: ncipollo/release-action@v2
+      - uses: ncipollo/release-action@v1.10.0
         with:
          artifacts: "build/app/outputs/flutter-apk/*.apk"

--- a/.github/workflows/flutter-build.yaml
+++ b/.github/workflows/flutter-build.yaml
@@ -22,10 +22,23 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: "3.0.1"
-      - run: flutter pub get
-      - run: flutter analyze
-      - run: flutter test
-      - run: flutter build apk --release
-      - uses: ncipollo/release-action@v1.10.0
+
+      - name: Pub Get Packages
+        run: flutter pub get
+
+      - name: Lint the app
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Build apk
+        run: flutter build apk --release
+
+      - name: Build app bundle (aab)
+        run: flutter build appbundle --release
+
+      - name: Create github release
+        uses: ncipollo/release-action@v1.10.0
         with:
-         artifacts: "build/app/outputs/flutter-apk/*.apk"
+          artifacts: "build/app/outputs/flutter-apk/*.apk,build/app/outputs/bundle/release/*.aab"

--- a/.github/workflows/flutter-build.yaml
+++ b/.github/workflows/flutter-build.yaml
@@ -1,0 +1,31 @@
+name: CI - Build
+
+on: 
+  push:
+    tags:
+    - '*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  releases:
+    name: release apk
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "11.x"
+      - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: "3.0.1"
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test
+      - run: flutter build apk --release
+      - uses: ncipollo/release-action@v2
+        with:
+         artifacts: "build/app/outputs/flutter-apk/*.apk"

--- a/.github/workflows/flutter-test.yaml
+++ b/.github/workflows/flutter-test.yaml
@@ -1,9 +1,6 @@
-# This is a basic workflow to help you get started with Actions
-name: CI
+name: CI - Test
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     paths-ignore:
       - '**/README.md'
@@ -13,12 +10,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
     name: flutter build
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,5 +24,5 @@ jobs:
         with:
           flutter-version: "3.0.1"
       - run: flutter pub get
-      #- run: flutter analyze
+      - run: flutter analyze
       - run: flutter test

--- a/.github/workflows/flutter-test.yaml
+++ b/.github/workflows/flutter-test.yaml
@@ -23,6 +23,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.0.1"
-      - run: flutter pub get
-      - run: flutter analyze
-      - run: flutter test
+
+      - name: Pub Get Packages
+        run: flutter pub get
+
+      - name: Lint the app
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test

--- a/README.md
+++ b/README.md
@@ -34,3 +34,18 @@ To connect to iOS simulator run the simulator installed with XCode see [Installa
 In vscode, in the bottom bar, select device type, and select your android emulator (or create a new one).
 
 Then hit the run button in the menu, on the run and debug tab, and it should start building an android debug application.
+
+
+## Github actions
+
+Github actions is used to run tests and create builds, and eventually create new releases to App store and Google Play.
+
+The ci scripts are located in the `.github/workflows/` folder.
+
+You can use a tool called [`ack`](https://github.com/nektos/act) to run these actions locally.
+
+Docker is used to build and run the actions locally.
+
+1. `brew install ack`
+2. `ack -l` to list actions available
+3. `ack` to run the default "push" event action (run tests).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,7 +96,7 @@ class _MyHomePageState extends State<MyHomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             const Text(
-              'You have pushed the button this many times:',
+              'Test. You have pushed the button this many times:',
             ),
             Text(
               '$_counter',


### PR DESCRIPTION
Whenever we create or push a new git tag, this new github action should build, analyze, test, and create android apk, and then create a new github release with the android apk